### PR TITLE
Fix Missing CSS Blur on Firefox

### DIFF
--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -97,6 +97,13 @@
   }
 }
 
+/* Slightly transparent fallback for Firefox since backdrop-filter is not enabled by default */
+@supports not ((-webkit-backdrop-filter: none) or (backdrop-filter: none)) {
+  .card {
+    background-color: rgba(255, 255, 255, .8);
+  }
+}
+
 .card:hover,
 .card:focus,
 .card:active {

--- a/styles/Location.module.css
+++ b/styles/Location.module.css
@@ -102,6 +102,13 @@
   }
 }
 
+/* Slightly transparent fallback for Firefox since backdrop-filter is not enabled by default */
+@supports not ((-webkit-backdrop-filter: none) or (backdrop-filter: none)) {
+  .card {
+    background-color: rgba(255, 255, 255, .8);
+  }
+}
+
 /*
 .card:hover,
 .card:focus,


### PR DESCRIPTION
`backdrop-filter` is not available by default in Firefox: https://caniuse.com/css-backdrop-filter